### PR TITLE
Named Register Get/Set/Dump

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,34 @@
+name: Rust
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+    - uses: BSFishy/pip-action@v1
+      with:
+        packages: pandare
+    - name: Build x86_64
+      run: cd panda-rs && cargo build --verbose
+    - name: Build i386
+      run: cd panda-rs && cargo build --verbose --no-default-features --features=i386
+    - name: Build ARM
+      run: cd panda-rs && cargo build --verbose --no-default-features --features=arm
+    - name: Build Mips
+      run: cd panda-rs && cargo build --verbose --no-default-features --features=mips
+    - name: Build Mips (Little Endian)
+      run: cd panda-rs && cargo build --verbose --no-default-features --features=mipsel
+    - name: Build PowerPC
+      run: cd panda-rs && cargo build --verbose --no-default-features --features=ppc

--- a/README.md
+++ b/README.md
@@ -58,10 +58,19 @@ however, if we want to make this into an executable that calls into libpanda  we
 ```rust
 fn main() {
     Panda::new()
-        .generic("x86_64") // use a generic x86_64 linux QCOW (a VM image) 
+        .generic("x86_64") // use a generic x86_64 linux QCOW (a VM image)
         .replay("my_application_replay") // load a replay of the name "my_application_replay"
         .run();
 }
 ```
 
 and enable the `libpanda` feature of panda-rs.
+
+## Executing Examples
+
+Sample snippets in the `panda-rs/examples` directory can be run by name, e.g. `showcase.rs` is executed with:
+
+```
+cd panda-rs
+cargo run --example showcase --features=libpanda
+```

--- a/panda-macros/src/lib.rs
+++ b/panda-macros/src/lib.rs
@@ -43,7 +43,7 @@ pub fn init(_: TokenStream, function: TokenStream) -> TokenStream {
 
                 #func_name(#args);
             }
-            
+
             #[no_mangle]
             unsafe extern "C" fn uninit_plugin(plugin: *mut ::panda::PluginHandle) {
                 for cb in ::panda::inventory::iter::<::panda::UninitCallback> {
@@ -157,14 +157,14 @@ pub fn derive_panda_args(input: TokenStream) -> TokenStream {
                 impl ::panda::PandaArgs for #ident {
                     fn from_panda_args() -> Self {
                         let name = ::std::ffi::CString::new(#name).unwrap();
-                        
+
                         unsafe {
                             let __args_ptr = ::panda::sys::panda_get_args(name.as_ptr());
 
                             #(
                                 #statements
                             )*
-                            
+
                             ::panda::sys::panda_free_args(__args_ptr);
 
                             Self {

--- a/panda-rs/Cargo.toml
+++ b/panda-rs/Cargo.toml
@@ -11,6 +11,10 @@ homepage = "https://panda-re.mit.edu"
 [lib]
 name = "panda"
 
+[[example]]
+name = "showcase"
+required-features = ["libpanda"]
+
 [dependencies]
 panda-re-sys = { version = "0.1", path = "../panda-sys" }
 panda-re-macros = { version = "0.3", path = "../panda-macros" }

--- a/panda-rs/Cargo.toml
+++ b/panda-rs/Cargo.toml
@@ -24,6 +24,8 @@ lazy_static = "1.4.0"
 libloading = "0.6.2"
 paste = "1.0.0"
 glib-sys = "0.10.0"
+strum = "0.20"
+strum_macros = "0.20"
 #llvm-ir = { version = "0.7.4", features = ["llvm-10"] }
 
 [features]

--- a/panda-rs/examples/dump_regs.rs
+++ b/panda-rs/examples/dump_regs.rs
@@ -1,0 +1,39 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::ffi::CStr;
+
+use panda::prelude::*;
+use panda::plugins::osi::OSI;
+
+static NUM_BB: AtomicU64 = AtomicU64::new(0);
+
+#[panda::init]
+fn init(_: &mut PluginHandle) {
+    // No specialized init needed
+}
+
+// Dump registers every 1000 basic blocks
+#[panda::before_block_exec]
+fn every_basic_block(cpu: &mut CPUState, tb: &mut TranslationBlock) {
+    if panda::in_kernel(cpu) {
+        return;
+    }
+
+    let curr_proc = OSI.get_current_process(cpu);
+    let curr_proc_name_c_str = unsafe { CStr::from_ptr((*curr_proc).name) };
+
+    if NUM_BB.fetch_add(1, Ordering::SeqCst) % 1000 == 0 {
+        println!("\nRegister state for process {:?} @ 0x{:016x}, {} basic blocks into execution:",
+            curr_proc_name_c_str,
+            tb.pc,
+            NUM_BB.load(Ordering::SeqCst) - 1,
+        );
+        panda::dump_regs(cpu);
+    }
+}
+
+fn main() {
+    Panda::new()
+        .generic("x86_64")
+        .replay("test")
+        .run();
+}

--- a/panda-rs/examples/showcase.rs
+++ b/panda-rs/examples/showcase.rs
@@ -15,7 +15,7 @@ struct Args {
 }
 
 #[panda::on_sys_write_enter]
-fn sys_write_test(cpu: &mut CPUState, pc: u64, fd: u64, buf: u64, count: u64) {
+fn sys_write_test(cpu: &mut CPUState, pc: target_ulong, fd: target_ulong, buf: target_ulong, count: target_ulong) {
     println!(
         "sys_write buf = \"{}\"",
         String::from_utf8_lossy(&cpu.mem_read(buf, count as usize))

--- a/panda-rs/src/api/mem.rs
+++ b/panda-rs/src/api/mem.rs
@@ -65,7 +65,7 @@ pub fn physical_memory_write(addr: target_ulong, data: &[u8]) -> MemRWStatus {
     let mut c_data = data.to_vec(); // Alloc b/c C API wants mut
     unsafe {
         panda_sys::panda_physical_memory_write_external(
-            addr,
+            addr as _,
             c_data.as_mut_ptr(),
             c_data.len() as i32,
         ).into()

--- a/panda-rs/src/api/mod.rs
+++ b/panda-rs/src/api/mod.rs
@@ -6,3 +6,6 @@ pub use mem::*;
 
 mod misc;
 pub use misc::*;
+
+mod regs;
+pub use regs::*;

--- a/panda-rs/src/api/mod.rs
+++ b/panda-rs/src/api/mod.rs
@@ -9,3 +9,6 @@ pub use misc::*;
 
 mod regs;
 pub use regs::*;
+
+mod utils;
+pub use utils::*;

--- a/panda-rs/src/api/regs.rs
+++ b/panda-rs/src/api/regs.rs
@@ -123,7 +123,7 @@ static RET_REGS: &'static [Reg] = &[Reg::V0, Reg::V1];
 // TODO: reg map
 /// AARCH64 named guest registers
 //#[cfg(feature = "aarch64")]
-//#[derive(Debug, PartialEq, Eq, EnumString, EnumIter)]
+//#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumString, EnumIter)]
 
 // TODO: support floating point set as well? Separate QEMU bank.
 /// PPC named guest registers
@@ -165,7 +165,7 @@ pub enum Reg {
     LR = 100, // Special case - separate bank in QEMU
 }
 
-/// MIPS return registers
+/// PPC return registers
 #[cfg(feature = "ppc")]
 static RET_REGS: &'static [Reg] = &[Reg::R3, Reg::R4];
 
@@ -202,14 +202,11 @@ pub fn reg_ret_addr() -> Option<Reg> {
     #[cfg(feature = "x86_64")]
     return None;
 
-    #[cfg(feature = "arm")]
+    #[cfg(any(feature = "arm", feature = "ppc"))]
     return Some(Reg::LR);
 
     #[cfg(any(feature = "mips", feature = "mipsel"))]
     return Some(Reg::RA);
-
-    #[cfg(feature = "ppc")]
-    return Some(Reg::LR);
 }
 
 /// Read the current value of a register

--- a/panda-rs/src/api/regs.rs
+++ b/panda-rs/src/api/regs.rs
@@ -1,7 +1,8 @@
+use std::string::ToString;
 use crate::prelude::*;
 use crate::{cpu_arch_state, CPUArchPtr};
 
-use strum_macros::{EnumString, EnumIter};
+use strum_macros::{EnumString, EnumIter, ToString};
 use strum::IntoEnumIterator;
 
 // Arch-specific mappings ----------------------------------------------------------------------------------------------
@@ -9,7 +10,7 @@ use strum::IntoEnumIterator;
 // TODO: handle AX/AH/AL, etc via shifts? Tricky b/c enum val used to index QEMU array
 /// x86 named guest registers
 #[cfg(feature = "i386")]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumString, EnumIter)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumString, EnumIter, ToString)]
 pub enum Reg {
     EAX = 0,
     ECX = 1,
@@ -28,7 +29,7 @@ static RET_REGS: &'static [Reg] = &[Reg::EAX];
 // TODO: handle EAX/AX/AH/AL, etc via shifts? Tricky b/c enum val used to index QEMU array
 /// x64 named guest registers
 #[cfg(feature = "x86_64")]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumString, EnumIter)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumString, EnumIter, ToString)]
 pub enum Reg {
     RAX = 0,
     RCX = 1,
@@ -54,7 +55,7 @@ static RET_REGS: &'static [Reg] = &[Reg::RAX];
 
 /// ARM named guest registers
 #[cfg(feature = "arm")]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumString, EnumIter)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumString, EnumIter, ToString)]
 pub enum Reg {
     R0 = 0,
     R1 = 1,
@@ -80,7 +81,7 @@ static RET_REGS: &'static [Reg] = &[Reg::R0, Reg::R1, Reg::R2, Reg::R3];
 
 /// MIPS named guest registers
 #[cfg(any(feature = "mips", feature = "mipsel"))]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumString, EnumIter)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumString, EnumIter, ToString)]
 pub enum Reg {
     ZERO = 0,
     AT = 1,
@@ -128,7 +129,7 @@ static RET_REGS: &'static [Reg] = &[Reg::V0, Reg::V1];
 // TODO: support floating point set as well? Separate QEMU bank.
 /// PPC named guest registers
 #[cfg(feature = "ppc")]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumString, EnumIter)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumString, EnumIter, ToString)]
 pub enum Reg {
     R0 = 0,
     R1 = 1,

--- a/panda-rs/src/api/regs.rs
+++ b/panda-rs/src/api/regs.rs
@@ -1,0 +1,183 @@
+use crate::prelude::*;
+
+use strum_macros::{EnumString, EnumIter};
+
+// Arch-specific mappings ----------------------------------------------------------------------------------------------
+
+// TODO: handle AX/AH/AL, etc via shifts?
+#[cfg(feature = "i386")]
+#[derive(Debug, PartialEq, Eq, EnumString, EnumIter)]
+enum Reg {
+    EAX = 0,
+    ECX = 1,
+    EDX = 2,
+    EBX = 3,
+    ESP = 4,
+    EBP = 5,
+    ESI = 6,
+    EDI = 7,
+}
+
+// TODO: handle EAX/AX/AH/AL, etc via shifts?
+#[cfg(feature = "x86_64")]
+#[derive(Debug, PartialEq, Eq, EnumString, EnumIter)]
+enum Reg {
+    RAX = 0,
+    RCX = 1,
+    RDX = 2,
+    RBX = 3,
+    RSP = 4,
+    RBP = 5,
+    RSI = 6,
+    RDI = 7,
+    R8 = 8,
+    R9 = 9,
+    R10 = 10,
+    R11 = 11,
+    R12 = 12,
+    R13 = 13,
+    R14 = 14,
+    R15 = 15,
+}
+
+#[cfg(feature = "arm")]
+#[derive(Debug, PartialEq, Eq, EnumString, EnumIter)]
+enum Reg {
+    R0 = 0,
+    R1 = 1,
+    R2 = 2,
+    R3 = 3,
+    R4 = 4,
+    R5 = 5,
+    R6 = 6,
+    R7 = 7,
+    R8 = 8,
+    R9 = 9,
+    R10 = 10,
+    R11 = 11,
+    R12 = 12,
+    LR = 13,
+    SP = 14,
+    IP = 15,
+}
+
+// TODO: reg map
+//#[cfg(feature = "aarch64")]
+//#[derive(Debug, PartialEq, Eq, EnumString, EnumIter)]
+
+// TODO: reg map
+#[cfg(feature = "mips, mipsel")]
+#[derive(Debug, PartialEq, Eq, EnumString, EnumIter)]
+enum Reg {
+    ZERO = 0,
+    AT = 1,
+    V0 = 2,
+    V1 = 3,
+    A0 = 4,
+    A1 = 5,
+    A2 = 6,
+    A3 = 7,
+    T0 = 8,
+    T1 = 9,
+    T2 = 10,
+    T3 = 11,
+    T4 = 12,
+    T5 = 13,
+    T6 = 14,
+    T7 = 15,
+    S0 = 16,
+    S1 = 17,
+    S2 = 18,
+    S3 = 19,
+    S4 = 20,
+    S5 = 21,
+    S6 = 22,
+    S7 = 23,
+    T8 = 24,
+    T9 = 25,
+    K0 = 26,
+    K1 = 27,
+    GP = 28,
+    SP = 29,
+    FP = 30,
+    RA = 31,
+}
+
+// TODO: reg map
+//#[cfg(feature = "ppc")]
+//#[derive(Debug, PartialEq, Eq, EnumString, EnumIter)]
+
+// Getter/setter -------------------------------------------------------------------------------------------------------
+
+/// Get stack pointer register
+fn reg_sp() -> Reg {
+
+    #[cfg(feature = "i386")]
+    return Reg::ESP;
+
+    #[cfg(feature = "x86_64")]
+    return Reg::RSP;
+
+    #[cfg(feature = "arm")]
+    return Reg::SP;
+
+    #[cfg(feature = "mips")]
+    return Reg::SP;
+}
+
+/// Get return value register
+/// MIPS note: returns `v0`, but `v1` may additionally be used in some cases.
+fn reg_ret_val() -> Reg {
+
+    #[cfg(feature = "i386")]
+    return Reg::EAX;
+
+    #[cfg(feature = "x86_64")]
+    return Reg::RAX;
+
+    #[cfg(feature = "arm")]
+    return Reg::SP;
+
+    #[cfg(feature = "mips")]
+    return Reg::V0;
+}
+
+/// Get return address register
+fn reg_ret_addr() -> Option<Reg> {
+
+    #[cfg(feature = "i386")]
+    return None;
+
+    #[cfg(feature = "x86_64")]
+    return None;
+
+    #[cfg(feature = "arm")]
+    return Some(Reg::LR);
+
+    #[cfg(feature = "mips")]
+    return Some(Reg::RA);
+}
+
+/// Read the current value of a register
+fn get_reg(cpu: &CPUState, reg: Reg) -> target_ulong {
+    let mut val;
+    unsafe {
+        if cfg!(feature = "mips") {
+            val = (*cpu.env_ptr).active_tc.gpr[reg];
+        } else {
+            val = (*cpu.env_ptr).regs[reg];
+        }
+    }
+    val
+}
+
+/// Set the value for a register
+fn set_reg(cpu: &CPUState, reg: Reg, val: target_ulong) {
+    unsafe {
+        if cfg!(feature = "mips") {
+            (*cpu.env_ptr).active_tc.gpr[reg] = reg;
+        } else {
+            (*cpu.env_ptr).regs[reg] = val;
+        }
+    }
+}

--- a/panda-rs/src/api/utils.rs
+++ b/panda-rs/src/api/utils.rs
@@ -1,33 +1,18 @@
-// TODO: cannot live in panda-macros due to arch feature flags?
-
-#[macro_export]
 #[cfg(any(feature = "i386", feature = "x86_64"))]
-macro_rules! cpu_arch_state {
-    ($cpu:expr) => {
-        $cpu.env_ptr as *mut panda_sys::CPUX86State
-    }
-}
+pub type CPUArchPtr = *mut panda_sys::CPUX86State;
 
-#[macro_export]
 #[cfg(feature = "arm")]
-macro_rules! cpu_arch_state {
-    ($cpu:expr) => {
-        $cpu.env_ptr as *mut panda_sys::CPUARMState
-    }
-}
+pub type CPUArchPtr = *mut panda_sys::CPUARMState;
 
-#[macro_export]
 #[cfg(any(feature = "mips", feature = "mipsel"))]
-macro_rules! cpu_arch_state {
-    ($cpu:expr) => {
-        $cpu.env_ptr as *mut panda_sys::CPUMIPSState
-    }
-}
+pub type CPUArchPtr = *mut panda_sys::CPUMIPSState;
+
+#[cfg(feature = "ppc")]
+pub type CPUArchPtr = *mut panda_sys::CPUPPCState;
 
 #[macro_export]
-#[cfg(feature = "ppc")]
 macro_rules! cpu_arch_state {
     ($cpu:expr) => {
-        $cpu.env_ptr as *mut panda_sys::CPUPPCState
+        $cpu.env_ptr as CPUArchPtr
     }
 }

--- a/panda-rs/src/api/utils.rs
+++ b/panda-rs/src/api/utils.rs
@@ -1,0 +1,33 @@
+// TODO: cannot live in panda-macros due to arch feature flags?
+
+#[macro_export]
+#[cfg(any(feature = "i386", feature = "x86_64"))]
+macro_rules! cpu_arch_state {
+    ($cpu:expr) => {
+        $cpu.env_ptr as *mut panda_sys::CPUX86State
+    }
+}
+
+#[macro_export]
+#[cfg(feature = "arm")]
+macro_rules! cpu_arch_state {
+    ($cpu:expr) => {
+        $cpu.env_ptr as *mut panda_sys::CPUARMState
+    }
+}
+
+#[macro_export]
+#[cfg(any(feature = "mips", feature = "mipsel"))]
+macro_rules! cpu_arch_state {
+    ($cpu:expr) => {
+        $cpu.env_ptr as *mut panda_sys::CPUMIPSState
+    }
+}
+
+#[macro_export]
+#[cfg(feature = "ppc")]
+macro_rules! cpu_arch_state {
+    ($cpu:expr) => {
+        $cpu.env_ptr as *mut panda_sys::CPUPPCState
+    }
+}

--- a/panda-rs/src/library_mode/mod.rs
+++ b/panda-rs/src/library_mode/mod.rs
@@ -87,10 +87,10 @@ impl Panda {
     pub fn args<I, S>(&mut self, args: I) -> &mut Self
     where
         I: IntoIterator<Item = S>,
-        S: Into<String>,
+        S: AsRef<str>,
     {
         for arg in args {
-            self.arg(arg.into());
+            self.arg(arg.as_ref());
         }
 
         self

--- a/panda-sys/build.rs
+++ b/panda-sys/build.rs
@@ -1,17 +1,64 @@
 use std::{env, fs};
-use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
 
-const MISSING_ERROR: &'static str = "Missing PANDA_PATH. Please set it to the `build` folder in your panda install.";
+const MISSING_ERROR: &'static str = "Missing PANDA_PATH. Please set it to the `build` folder in your panda install or use pip to install the `pandare` package.";
+const PYTHON_GET_SITE_PACKAGES: &'static str = r#"import sys; print("\n".join(sys.path))"#;
+
+fn get_site_packages() -> Result<Vec<PathBuf>, std::io::Error> {
+    Ok(
+        String::from_utf8_lossy(
+            &Command::new("python3")
+                .args(&["-c", PYTHON_GET_SITE_PACKAGES])
+                .output()
+                .or_else(|_|
+                    Command::new("python")
+                        .args(&["-c", PYTHON_GET_SITE_PACKAGES])
+                        .output()
+                )?
+                .stdout[..]
+        )
+        .split("\n")
+        .map(PathBuf::from)
+        .collect()
+    )
+}
+
+fn get_panda_path() -> PathBuf {
+    PathBuf::from(
+        &env::var("PANDA_PATH")
+            .map(PathBuf::from)
+            .or_else(|_| -> Result<_, ()> {
+                Ok(
+                    get_site_packages()
+                        .map_err(|_| ())?
+                        .into_iter()
+                        .filter_map(|site_package_folder| {
+                            let path = site_package_folder.join("pandare").join("data");
+                            if path.exists() {
+                                Some(path)
+                            } else {
+                                None
+                            }
+                        })
+                        .next()
+                        .ok_or(())?
+                )
+            })
+            .expect(MISSING_ERROR)
+    )
+}
 
 fn main() {
     if cfg!(feature = "libpanda") {
         println!("libpanda mode enabled");
-        let dylib_path = Path::new(&env::var("PANDA_PATH").expect(MISSING_ERROR)).join("x86_64-softmmu");
+        let dylib_path = get_panda_path().join("x86_64-softmmu");
         println!("cargo:rustc-link-lib=dylib=panda-x86_64");
         println!("cargo:rustc-link-search=native={}", dylib_path.display());
 
-        let out_dir = env::var("OUT_DIR").unwrap();
-        let out_dir = Path::new(&out_dir);
+        let out_dir: PathBuf = env::var("OUT_DIR").unwrap().into();
         fs::copy(dylib_path.join("libpanda-x86_64.so"), out_dir.join("..").join("..").join("..").join("libpanda-x86_64.so")).unwrap();
+        //println!("cargo:rustc-link-search=dylib={}", out_dir.join("..").join("..").join("..").display());
+        //println!("cargo:rustc-link-search=dylib=/lib/x86_64-linux-gnu");
     }
 }


### PR DESCRIPTION
Adds named register getter/setter functions and a dump function to print all register state. Runnable example added to `panda-rs/examples`. Some intricacies to note:

- For performance and compile-time checking, API uses enums instead of string names (e.g. `get_reg(cpu, Reg::EAX)` and not `get_reg(cpu, "eax")` like Python). However, all the register enums derive a to/from `String` (added `strum` crate as dep), so a CLI tool could take in register strings, etc.
- Added simple macros to handle conversion to arch-specific CPU state, but had to put them in `panda-rs` and not `panda-macros` due to arch-specific conditional compilation.
- Like the Python and C, this doesn't support subset registers (e.g. `AX`/`AH`/`AL` for x86's `EAX`) so caller must shift if necessary.

Lemme know if any changes are needed!