### PR TITLE
Add GBoxedSlice to handle GArray in a better manner

### DIFF
--- a/panda-rs/src/api/regs.rs
+++ b/panda-rs/src/api/regs.rs
@@ -1,4 +1,3 @@
-use std::string::ToString;
 use crate::prelude::*;
 use crate::{cpu_arch_state, CPUArchPtr};
 

--- a/panda-rs/src/plugins/glib.rs
+++ b/panda-rs/src/plugins/glib.rs
@@ -1,7 +1,9 @@
 use std::mem::size_of;
+use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
-use glib_sys::{g_malloc, g_free, gpointer};
+use glib_sys::{g_malloc, g_free, gpointer, g_array_free, GArray};
 
+/// An owned glib-allocated value that will be freed using glib's allocator on drop.
 #[repr(transparent)]
 pub struct GBox<T>(*mut T);
 
@@ -37,6 +39,39 @@ impl<T> Drop for GBox<T> {
     fn drop(&mut self) {
         unsafe {
             g_free(self.0 as gpointer);
+        }
+    }
+}
+
+#[repr(transparent)]
+pub struct GBoxedSlice<T>(*mut GArray, PhantomData<T>);
+
+impl<T> Deref for GBoxedSlice<T> {
+    type Target = [T];
+    
+    fn deref(&self) -> &Self::Target {
+        let g_array = unsafe { &*self.0 };
+
+        unsafe {
+            std::slice::from_raw_parts(g_array.data as _, g_array.len as usize)
+        }
+    }
+}
+
+impl<T> DerefMut for GBoxedSlice<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        let g_array = unsafe { &mut *self.0 };
+
+        unsafe {
+            std::slice::from_raw_parts_mut(g_array.data as *mut T, g_array.len as usize)
+        }
+    }
+}
+
+impl<T> Drop for GBoxedSlice<T> {
+    fn drop(&mut self) {
+        unsafe {
+            g_array_free(self.0, true as _);
         }
     }
 }

--- a/panda-rs/src/plugins/mod.rs
+++ b/panda-rs/src/plugins/mod.rs
@@ -16,7 +16,16 @@ macro_rules! plugin_import {
             $(
                 #[$meta:meta]
              )*
-            fn $fn_name:ident(
+            fn $fn_name:ident
+                $(
+                    <
+                        $(
+                            $lifetimes:lifetime
+                        ),*
+                        $(,)?
+                    >
+                )?
+            (
                 $(
                     $arg_name:ident : $arg_ty:ty
                  ),*
@@ -56,7 +65,7 @@ macro_rules! plugin_import {
                 $(
                     #[$meta]
                  )*
-                pub fn $fn_name(&self $(, $arg_name : $arg_ty )*) $(-> $fn_ret)? {
+                pub fn $fn_name $(< $($lifetimes),* >)? (&self $(, $arg_name : $arg_ty )*) $(-> $fn_ret)? {
                     unsafe {
                         self.plugin.get::<unsafe extern "C" fn($($arg_ty),*) $(-> $fn_ret)?>(
                             stringify!($fn_name)

--- a/panda-rs/src/plugins/osi.rs
+++ b/panda-rs/src/plugins/osi.rs
@@ -1,5 +1,5 @@
 use crate::sys::{target_ptr_t, target_pid_t, target_ulong, CPUState};
-use crate::plugins::glib::GBox;
+use crate::plugins::glib::{GBox, GBoxedSlice};
 use crate::plugin_import;
 
 use std::ffi::CStr;
@@ -11,9 +11,9 @@ plugin_import!{
     static OSI: Osi = extern "osi" {
         fn get_process_handles(cpu: *mut CPUState) -> *mut GArray;
         fn get_current_thread(cpu: *mut CPUState) -> GBox<OsiThread>;
-        fn get_modules(cpu: *mut CPUState) -> *mut GArray;
-        fn get_mappings(cpu: *mut CPUState, p: *mut OsiProc) -> *mut GArray;
-        fn get_processes(cpu: *mut CPUState) -> *mut GArray;
+        fn get_modules(cpu: *mut CPUState) -> GBoxedSlice<OsiModule>;
+        fn get_mappings(cpu: *mut CPUState, p: *mut OsiProc) -> GBoxedSlice<OsiModule>;
+        fn get_processes(cpu: *mut CPUState) -> GBoxedSlice<OsiProc>;
         fn get_current_process(cpu: *mut CPUState) -> GBox<OsiProc>;
         fn get_one_module(osimodules: *mut GArray, idx: ::std::os::raw::c_uint) -> *mut OsiModule;
         fn get_one_proc(osiprocs: *mut GArray, idx: ::std::os::raw::c_uint) -> *mut OsiProc;


### PR DESCRIPTION
Still needs more testing, but making a PR for any discussion needed.

Some notes/possible pitfalls:

* `GArray` does not have inherent lifetime properties, it can effectively be either the equivalent of `Box<[T]>` (owned) or `&[T}` (boxed)
* `GBoxedSlice<T>` is designed to cover the `Box<[T]>` case
* In theory the `Deref`/`DerefMut` implementations included are sound, however might need to double check that glib guarantees the same layout requirements as Rust's slice types
    * If this is not the case, it might be best to implement indexing and any other operations we want by hand
*  panda seems to only use the owned `GArray` variant, however this might require further verification