### PR TITLE
Fix bhe and bhi return values

### DIFF
--- a/panda-macros/src/base_callbacks.rs
+++ b/panda-macros/src/base_callbacks.rs
@@ -781,8 +781,8 @@ define_callback_attributes!(
        the new exception index, which will replace
        cpu->exception_index
      "
-    (before_handle_exception, panda_cb_type_PANDA_CB_BEFORE_HANDLE_EXCEPTION, (cpu: &mut CPUState, exception_index: i32)),
-    (before_handle_interrupt, panda_cb_type_PANDA_CB_BEFORE_HANDLE_INTERRUPT, (cpu: &mut CPUState, exception_index: i32)),
+    (before_handle_exception, panda_cb_type_PANDA_CB_BEFORE_HANDLE_EXCEPTION, (cpu: &mut CPUState, exception_index: i32) -> i32),
+    (before_handle_interrupt, panda_cb_type_PANDA_CB_BEFORE_HANDLE_INTERRUPT, (cpu: &mut CPUState, exception_index: i32) -> i32),
 
     " Callback ID: PANDA_CB_START_BLOCK_EXEC
 


### PR DESCRIPTION
The callbacks before_handle_exception and before_handle_interrupt were changed in core PANDA to return an int32_t: https://github.com/panda-re/panda/blob/068f901777cd58a28251e1b1b5856c304476f05b/panda/include/panda/callbacks/cb-defs.h#L1921-L1962

This change updates `base_callbacks.rs` to reflect that change.